### PR TITLE
Apply mint & midnight dark theme

### DIFF
--- a/app/friends/page.tsx
+++ b/app/friends/page.tsx
@@ -23,27 +23,27 @@ export default function FriendsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="p-4 border rounded-2xl">
-        <h2 className="font-medium mb-2">Add a friend by phone</h2>
+      <div className="p-4 border border-primary/25 bg-surface rounded-2xl">
+        <h2 className="font-medium mb-2 text-headline">Add a friend by phone</h2>
         <form action={async () => { await createFriendByPhone(phone); setPhone(''); }} className="flex gap-2">
-          <input className="border rounded-xl px-3 py-2 flex-1" placeholder="+372..." value={phone} onChange={e=>setPhone(e.target.value)} />
-          <button className="px-3 py-2 rounded-xl bg-primary text-white">Add</button>
+          <input className="border border-primary/25 rounded-xl px-3 py-2 flex-1" placeholder="+372..." value={phone} onChange={e=>setPhone(e.target.value)} />
+          <button className="px-3 py-2 rounded-xl bg-primary text-headline">Add</button>
         </form>
         <p className="text-sm text-muted mt-2">They will need to accept your request.</p>
       </div>
 
       <div>
-        <h2 className="font-semibold mb-2">Your Friends</h2>
+        <h2 className="font-semibold mb-2 text-headline">Your Friends</h2>
         <div className="space-y-2">
           {friends.map((f:any) => (
-            <div key={f.id} className="border rounded-xl p-3 flex items-center justify-between">
+            <div key={f.id} className="border border-primary/25 bg-surface rounded-xl p-3 flex items-center justify-between">
               <div>
-                <div className="font-medium">{f.friend_display_name ?? f.friend_phone ?? f.friend_id}</div>
+                <div className="font-medium text-headline">{f.friend_display_name ?? f.friend_phone ?? f.friend_id}</div>
                 <div className="text-sm text-muted">{f.status}</div>
               </div>
               {f.status === 'pending_me' && (
                 <form action={acceptFriend.bind(null, f.friend_id)}>
-                  <button className="text-sm px-3 py-1 rounded-xl border">Accept</button>
+                  <button className="text-sm px-3 py-1 rounded-xl border border-primary/25 bg-surface">Accept</button>
                 </form>
               )}
             </div>
@@ -52,7 +52,7 @@ export default function FriendsPage() {
       </div>
 
       <div>
-        <h2 className="font-semibold mb-2">Share a Book</h2>
+        <h2 className="font-semibold mb-2 text-headline">Share a Book</h2>
         {books.length === 0 && <p className="text-sm text-muted">Create a book by assigning one when adding a recipe (default is created automatically).</p>}
         <div className="grid md:grid-cols-2 gap-3">
           {books.map(b => (
@@ -67,15 +67,15 @@ export default function FriendsPage() {
 function ShareCard({ book, friends }:{ book:any, friends:any[] }) {
   const [selected, setSelected] = useState<string>('');
   return (
-    <div className="border rounded-2xl p-3">
-      <div className="font-medium mb-2">{book.name}</div>
+    <div className="border border-primary/25 bg-surface rounded-2xl p-3">
+      <div className="font-medium mb-2 text-headline">{book.name}</div>
       <div className="flex gap-2">
-        <select className="border rounded-xl px-3 py-2 flex-1" value={selected} onChange={e => setSelected(e.target.value)}>
+        <select className="border border-primary/25 rounded-xl px-3 py-2 flex-1 bg-surface" value={selected} onChange={e => setSelected(e.target.value)}>
           <option value="">Choose friend…</option>
           {friends.map(f => <option key={f.friend_id} value={f.friend_id}>{f.friend_display_name ?? f.friend_phone ?? f.friend_id}</option>)}
         </select>
         <form action={async () => { if(!selected) return; await shareBook(book.id, selected, 'view'); }}>
-          <button className="px-3 py-2 rounded-xl border">Share</button>
+          <button className="px-3 py-2 rounded-xl border border-primary/25 bg-surface">Share</button>
         </form>
       </div>
     </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,14 +3,31 @@
 @tailwind utilities;
 
 :root {
-  --bg: #FFFFFF;
-  --text: #0F172A;
-  --primary: #16A34A;
-  --primaryDark: #15803D;
-  --accent: #0EA5E9;
-  --muted: #64748B;
-  --ring: rgba(22,163,74,0.25);
+  --bg: #0B1220;
+  --surface: #0F172A;
+  --text: #C7EDE3;
+  --headline: #ECFEFF;
+  --primary: #10B981;
+  --primaryDark: #0F766E;
+  --accent: #38BDF8;
+  --muted: #94A3B8;
+  --ring: rgba(16,185,129,0.25);
+  --success: #22C55E;
 }
 
 html, body, #__next { height: 100%; }
 body { background: var(--bg); color: var(--text); }
+
+h1, h2, h3 {
+  color: var(--headline);
+}
+
+input, textarea, select {
+  background: var(--surface);
+  color: var(--text);
+  border-color: var(--ring);
+}
+
+button {
+  color: var(--headline);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,7 +13,7 @@ async function UserMenu() {
   const { data } = await supabase.auth.getUser();
   const user = data.user;
   if (!user) {
-    return <Link href="/login" className="text-sm px-3 py-1 rounded bg-primary text-white">Log in</Link>
+    return <Link href="/login" className="text-sm px-3 py-1 rounded bg-primary text-headline">Log in</Link>
   }
   async function signOut() {
     'use server'
@@ -23,7 +23,7 @@ async function UserMenu() {
   }
   return (
     <form action={signOut}>
-      <button className="text-sm px-3 py-1 rounded bg-primaryDark text-white">Sign out</button>
+      <button className="text-sm px-3 py-1 rounded bg-primaryDark text-headline">Sign out</button>
     </form>
   )
 }
@@ -31,22 +31,21 @@ async function UserMenu() {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen">
-        <header className="border-b bg-white/80 backdrop-blur sticky top-0 z-10">
-          <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between">
-            <Link href="/" className="font-semibold text-lg">🥗 Recipe Planner</Link>
+      <body className="min-h-screen bg-bg text-text">
+        <header className="border-b border-primary/25 bg-surface sticky top-0 z-10">
+          <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between text-headline">
+            <Link href="/" className="font-semibold text-lg text-headline">🥗 Recipe Planner</Link>
             <nav className="flex items-center gap-3 text-sm">
               <Link href="/recipes" className="hover:text-primary">Recipes</Link>
               <Link href="/shopping" className="hover:text-primary">Shopping</Link>
               <Link href="/menu" className="hover:text-primary">Weekly Menu</Link>
               <Link href="/friends" className="hover:text-primary">Friends</Link>
             </nav>
-            {/* @ts-expect-error async server component */}
             <UserMenu />
           </div>
         </header>
         <main className="max-w-5xl mx-auto px-4 py-6">{children}</main>
-        <footer className="border-t mt-10 text-center text-sm text-muted py-6">Built with Next.js, Tailwind, Supabase</footer>
+        <footer className="border-t border-primary/25 mt-10 text-center text-sm text-muted py-6">Built with Next.js, Tailwind, Supabase</footer>
       </body>
     </html>
   )

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -35,28 +35,28 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="max-w-md mx-auto">
-      <h1 className="text-2xl font-semibold mb-4">Login with phone</h1>
+    <div className="max-w-md mx-auto p-6 border border-primary/25 bg-surface rounded-2xl">
+      <h1 className="text-2xl font-semibold mb-4 text-headline">Login with phone</h1>
       {step === 'phone' && (
         <form onSubmit={sendCode} className="space-y-3">
           <input
-            className="w-full border rounded-xl px-3 py-2"
+            className="w-full border border-primary/25 rounded-xl px-3 py-2"
             placeholder="+3725123456"
             value={phone}
             onChange={e => setPhone(e.target.value)}
           />
-          <button className="px-4 py-2 rounded-xl bg-primary text-white">Send code</button>
+          <button className="px-4 py-2 rounded-xl bg-primary text-headline">Send code</button>
         </form>
       )}
       {step === 'code' && (
         <form onSubmit={verify} className="space-y-3">
           <input
-            className="w-full border rounded-xl px-3 py-2"
+            className="w-full border border-primary/25 rounded-xl px-3 py-2"
             placeholder="6-digit code"
             value={code}
             onChange={e => setCode(e.target.value)}
           />
-          <button className="px-4 py-2 rounded-xl bg-primary text-white">Verify</button>
+          <button className="px-4 py-2 rounded-xl bg-primary text-headline">Verify</button>
         </form>
       )}
       {err && <p className="text-red-600 mt-3">{err}</p>}

--- a/app/menu/page.tsx
+++ b/app/menu/page.tsx
@@ -37,21 +37,21 @@ export default async function MenuPage() {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-xl font-semibold">Next Week&apos;s Menu</h1>
+      <h1 className="text-xl font-semibold text-headline">Next Week&apos;s Menu</h1>
       <div className="grid md:grid-cols-3 gap-4">
         {[1,2,3,4,5,6,7].map(d => {
           const date = dateForNextWeekDay(d);
           const key = date.toISOString().slice(0,10);
           const dayItems = map.get(key) ?? [];
           return (
-            <div key={d} className="border rounded-2xl p-3">
-              <div className="font-medium mb-2">{weekdayNames[d]} <span className="text-muted text-xs">({key})</span></div>
+            <div key={d} className="border border-primary/25 bg-surface rounded-2xl p-3">
+              <div className="font-medium mb-2 text-headline">{weekdayNames[d]} <span className="text-muted text-xs">({key})</span></div>
               <div className="space-y-2">
                 {dayItems.length === 0 && <p className="text-sm text-muted">No recipes yet. Add from the Recipes page.</p>}
                 {dayItems.map((item: any) => (
                   <div key={item.id} className="flex items-center gap-2">
-                    {item.recipes?.image_url ? <img src={item.recipes.image_url} className="h-10 w-10 rounded object-cover border" /> : <div className="h-10 w-10 rounded bg-gray-100" />}
-                    <div>{item.recipes?.title ?? 'Untitled'}</div>
+                    {item.recipes?.image_url ? <img src={item.recipes.image_url} className="h-10 w-10 rounded object-cover border border-primary/25" /> : <div className="h-10 w-10 rounded bg-surface border border-primary/25" />}
+                    <div className="text-headline">{item.recipes?.title ?? 'Untitled'}</div>
                   </div>
                 ))}
               </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,18 +8,18 @@ export default async function Home() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold">Welcome{authed ? '' : ' — please log in'}</h1>
+      <h1 className="text-2xl font-semibold text-headline">Welcome{authed ? '' : ' — please log in'}</h1>
       <div className="grid md:grid-cols-3 gap-4">
-        <Link href="/recipes" className="block p-4 border rounded-2xl shadow-sm hover:shadow-md">
-          <h3 className="font-medium mb-1">Add a recipe</h3>
+        <Link href="/recipes" className="block p-4 border border-primary/25 bg-surface rounded-2xl shadow-sm hover:shadow-md">
+          <h3 className="font-medium mb-1 text-headline">Add a recipe</h3>
           <p className="text-sm text-muted">Keep your recipes organized and attach images.</p>
         </Link>
-        <Link href="/shopping" className="block p-4 border rounded-2xl shadow-sm hover:shadow-md">
-          <h3 className="font-medium mb-1">Shopping list</h3>
+        <Link href="/shopping" className="block p-4 border border-primary/25 bg-surface rounded-2xl shadow-sm hover:shadow-md">
+          <h3 className="font-medium mb-1 text-headline">Shopping list</h3>
           <p className="text-sm text-muted">Aggregate ingredients — check items off at the store.</p>
         </Link>
-        <Link href="/menu" className="block p-4 border rounded-2xl shadow-sm hover:shadow-md">
-          <h3 className="font-medium mb-1">Plan next week</h3>
+        <Link href="/menu" className="block p-4 border border-primary/25 bg-surface rounded-2xl shadow-sm hover:shadow-md">
+          <h3 className="font-medium mb-1 text-headline">Plan next week</h3>
           <p className="text-sm text-muted">Drag recipes onto days (or quick-add with a click).</p>
         </Link>
       </div>

--- a/app/recipes/page.tsx
+++ b/app/recipes/page.tsx
@@ -19,7 +19,7 @@ export default async function RecipesPage() {
     <div className="space-y-6">
       <RecipeForm />
       <div>
-        <h2 className="font-semibold text-lg mb-2">Your Recipes</h2>
+        <h2 className="font-semibold text-lg mb-2 text-headline">Your Recipes</h2>
         <RecipeList recipes={(recipes ?? []).map(r => ({ id: r.id, title: r.title, image_url: r.image_url }))} />
       </div>
     </div>

--- a/app/shopping/page.tsx
+++ b/app/shopping/page.tsx
@@ -31,13 +31,13 @@ export default async function ShoppingPage() {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-xl font-semibold">Shopping List</h1>
+      <h1 className="text-xl font-semibold text-headline">Shopping List</h1>
       <div className="space-y-2">
         {items && items.length === 0 && <p className="text-muted">No items yet — add some from a recipe.</p>}
         {items && items.map(i => (
-          <form key={i.id} action={toggleShoppingItem.bind(null, i.id, !i.checked)} className="flex items-center gap-3 border rounded-xl px-3 py-2">
-            <button className={"h-5 w-5 rounded border " + (i.checked ? "bg-primary" : "bg-white")} aria-label="toggle" />
-            <div className={"flex-1 " + (i.checked ? "line-through text-muted" : "")}>
+          <form key={i.id} action={toggleShoppingItem.bind(null, i.id, !i.checked)} className="flex items-center gap-3 border border-primary/25 bg-surface rounded-xl px-3 py-2">
+            <button className={"h-5 w-5 rounded border border-primary/25 " + (i.checked ? "bg-primary" : "bg-surface") } aria-label="toggle" />
+            <div className={"flex-1 " + (i.checked ? "line-through text-muted" : "text-headline")}> 
               {i.name} {i.quantity ? `— ${i.quantity} ${i.unit ?? ''}` : ''}
             </div>
           </form>

--- a/components/RecipeForm.tsx
+++ b/components/RecipeForm.tsx
@@ -23,30 +23,30 @@ export default function RecipeForm({ bookId }: { bookId?: string | null }) {
     setTitle(''); setDirections(''); setImageUrl(null); setIngredients([{ name: '' }]);
   }
 
-  return (
-    <form onSubmit={onSubmit} className="p-4 border rounded-2xl space-y-3">
-      <h3 className="font-medium">New Recipe</h3>
-      <input className="w-full border rounded-xl px-3 py-2" placeholder="Title" value={title} onChange={e => setTitle(e.target.value)} required />
-      <textarea className="w-full border rounded-xl px-3 py-2" placeholder="Directions" rows={4} value={directions} onChange={e => setDirections(e.target.value)} />
-      <div className="flex items-center gap-3">
-        <UploadImage onUploaded={setImageUrl} />
-        {imageUrl && <img src={imageUrl} alt="preview" className="h-16 w-16 rounded object-cover border" />}
-      </div>
-      <div>
-        <p className="text-sm font-medium mb-1">Ingredients</p>
-        <div className="space-y-2">
-          {ingredients.map((ing, i) => (
-            <div key={i} className="grid grid-cols-12 gap-2">
-              <input className="col-span-6 border rounded-xl px-3 py-2" placeholder="Name" value={ing.name} onChange={e => updateIng(i,'name',e.target.value)} />
-              <input className="col-span-3 border rounded-xl px-3 py-2" placeholder="Qty" value={ing.quantity ?? ''} onChange={e => updateIng(i,'quantity',e.target.value)} />
-              <input className="col-span-2 border rounded-xl px-3 py-2" placeholder="Unit" value={ing.unit ?? ''} onChange={e => updateIng(i,'unit',e.target.value)} />
-              <button type="button" onClick={() => removeIng(i)} className="col-span-1 text-sm text-red-600">✕</button>
-            </div>
-          ))}
-          <button type="button" onClick={addIng} className="text-sm text-primary">+ Add ingredient</button>
+    return (
+      <form onSubmit={onSubmit} className="p-4 border border-primary/25 bg-surface rounded-2xl space-y-3">
+        <h3 className="font-medium text-headline">New Recipe</h3>
+        <input className="w-full border border-primary/25 rounded-xl px-3 py-2 bg-surface" placeholder="Title" value={title} onChange={e => setTitle(e.target.value)} required />
+        <textarea className="w-full border border-primary/25 rounded-xl px-3 py-2 bg-surface" placeholder="Directions" rows={4} value={directions} onChange={e => setDirections(e.target.value)} />
+        <div className="flex items-center gap-3">
+          <UploadImage onUploaded={setImageUrl} />
+          {imageUrl && <img src={imageUrl} alt="preview" className="h-16 w-16 rounded object-cover border border-primary/25" />}
         </div>
-      </div>
-      <button className="px-4 py-2 rounded-xl bg-primary text-white">Save Recipe</button>
-    </form>
-  )
-}
+        <div>
+          <p className="text-sm font-medium mb-1 text-headline">Ingredients</p>
+          <div className="space-y-2">
+            {ingredients.map((ing, i) => (
+              <div key={i} className="grid grid-cols-12 gap-2">
+                <input className="col-span-6 border border-primary/25 rounded-xl px-3 py-2 bg-surface" placeholder="Name" value={ing.name} onChange={e => updateIng(i,'name',e.target.value)} />
+                <input className="col-span-3 border border-primary/25 rounded-xl px-3 py-2 bg-surface" placeholder="Qty" value={ing.quantity ?? ''} onChange={e => updateIng(i,'quantity',e.target.value)} />
+                <input className="col-span-2 border border-primary/25 rounded-xl px-3 py-2 bg-surface" placeholder="Unit" value={ing.unit ?? ''} onChange={e => updateIng(i,'unit',e.target.value)} />
+                <button type="button" onClick={() => removeIng(i)} className="col-span-1 text-sm text-red-600">✕</button>
+              </div>
+            ))}
+            <button type="button" onClick={addIng} className="text-sm text-primary">+ Add ingredient</button>
+          </div>
+        </div>
+        <button className="px-4 py-2 rounded-xl bg-primary text-headline">Save Recipe</button>
+      </form>
+    )
+  }

--- a/components/RecipeList.tsx
+++ b/components/RecipeList.tsx
@@ -12,20 +12,20 @@ export default function RecipeList({ recipes }:{ recipes: Recipe[] }) {
   return (
     <div className="grid sm:grid-cols-2 md:grid-cols-3 gap-4">
       {recipes.map(r => (
-        <div key={r.id} className="border rounded-2xl overflow-hidden">
-          {r.image_url ? <img src={r.image_url} alt="" className="w-full h-40 object-cover" /> : <div className="h-40 bg-gray-100" />}
+        <div key={r.id} className="border border-primary/25 bg-surface rounded-2xl overflow-hidden">
+          {r.image_url ? <img src={r.image_url} alt="" className="w-full h-40 object-cover" /> : <div className="h-40 bg-surface" />}
           <div className="p-3">
-            <div className="font-medium mb-2">{r.title}</div>
+            <div className="font-medium mb-2 text-headline">{r.title}</div>
             <div className="flex flex-wrap gap-2">
               <form action={addIngredientsToShoppingList.bind(null, r.id)}>
-                <button className="text-sm px-3 py-1 border rounded-xl">Add to shopping list</button>
+                <button className="text-sm px-3 py-1 border border-primary/25 rounded-xl bg-surface">Add to shopping list</button>
               </form>
               <details className="text-sm">
-                <summary className="px-3 py-1 border rounded-xl cursor-pointer select-none inline-block">Add to next week</summary>
+                <summary className="px-3 py-1 border border-primary/25 rounded-xl cursor-pointer select-none inline-block bg-surface">Add to next week</summary>
                 <div className="mt-2 grid grid-cols-2 gap-2">
                   {[1,2,3,4,5,6,7].map(d => (
                     <form key={d} action={async () => { 'use server'; await addRecipeToNextWeekMenu(r.id, d as any) }}>
-                      <button className="px-2 py-1 border rounded-xl w-full">{weekdayNames[d]}</button>
+                      <button className="px-2 py-1 border border-primary/25 rounded-xl w-full bg-surface">{weekdayNames[d]}</button>
                     </form>
                   ))}
                 </div>

--- a/components/UploadImage.tsx
+++ b/components/UploadImage.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useState } from 'react';
 import { supabaseBrowser } from '@/lib/supabaseBrowser';
-import { v4 as uuidv4 } from 'uuid';
 
 // simple local uuid implementation if uuid is not installed
 function simpleId() { return Math.random().toString(36).slice(2) + Date.now().toString(36); }
@@ -24,7 +23,7 @@ export default function UploadImage({ onUploaded }:{ onUploaded:(url:string)=>vo
   }
   return (
     <label className="inline-flex items-center gap-2 cursor-pointer">
-      <span className="px-3 py-2 border rounded-xl">{uploading ? 'Uploading...' : 'Upload image'}</span>
+      <span className="px-3 py-2 border border-primary/25 bg-surface rounded-xl">{uploading ? 'Uploading...' : 'Upload image'}</span>
       <input type="file" className="hidden" onChange={onFileChange} accept="image/*" />
     </label>
   )


### PR DESCRIPTION
## Summary
- add mint & midnight palette via CSS variables and base styling
- restyle layout, pages, and components with dark background and surface cards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad43faf0f4832aa117391552855efe