### PR TITLE
Add recipe detail page with shopping list actions

### DIFF
--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -1,0 +1,75 @@
+import { supabaseServer } from '@/lib/supabaseServer';
+import { addIngredientsToShoppingList, addRecipeToNextWeekMenu } from '@/lib/actions';
+import { weekdayNames } from '@/lib/date';
+import { redirect, notFound } from 'next/navigation';
+
+export default async function RecipePage({ params }: { params: { id: string } }) {
+  const supabase = supabaseServer();
+  const { data: auth } = await supabase.auth.getUser();
+  if (!auth.user) redirect('/login');
+
+  const { data: recipe } = await supabase
+    .from('recipes')
+    .select('*')
+    .eq('id', params.id)
+    .single();
+  if (!recipe) notFound();
+
+  const { data: ingredients } = await supabase
+    .from('recipe_ingredients')
+    .select('id, name, quantity, unit')
+    .eq('recipe_id', params.id);
+
+  return (
+    <div className="space-y-4">
+      {recipe.image_url && (
+        <img
+          src={recipe.image_url}
+          alt=""
+          className="w-full h-64 object-cover rounded-2xl border border-primary/25"
+        />
+      )}
+      <h1 className="text-xl font-semibold text-headline">{recipe.title}</h1>
+      {ingredients && ingredients.length > 0 && (
+        <div>
+          <h2 className="font-medium text-headline mb-1">Ingredients</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            {ingredients.map(i => (
+              <li key={i.id}>
+                {i.name}
+                {i.quantity ? ` — ${i.quantity} ${i.unit ?? ''}` : ''}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {recipe.directions && (
+        <div>
+          <h2 className="font-medium text-headline mb-1">Directions</h2>
+          <p className="whitespace-pre-line text-body">{recipe.directions}</p>
+        </div>
+      )}
+      <div className="flex flex-wrap gap-2">
+        <form action={addIngredientsToShoppingList.bind(null, recipe.id)}>
+          <button className="text-sm px-3 py-1 border border-primary/25 rounded-xl bg-surface">
+            Add to shopping list
+          </button>
+        </form>
+        <details className="text-sm">
+          <summary className="px-3 py-1 border border-primary/25 rounded-xl cursor-pointer select-none inline-block bg-surface">
+            Add to next week
+          </summary>
+          <div className="mt-2 grid grid-cols-2 gap-2">
+            {[1,2,3,4,5,6,7].map(d => (
+              <form key={d} action={async () => { 'use server'; await addRecipeToNextWeekMenu(recipe.id, d as any); }}>
+                <button className="px-2 py-1 border border-primary/25 rounded-xl w-full bg-surface">
+                  {weekdayNames[d]}
+                </button>
+              </form>
+            ))}
+          </div>
+        </details>
+      </div>
+    </div>
+  );
+}

--- a/components/RecipeList.tsx
+++ b/components/RecipeList.tsx
@@ -15,7 +15,9 @@ export default function RecipeList({ recipes }:{ recipes: Recipe[] }) {
         <div key={r.id} className="border border-primary/25 bg-surface rounded-2xl overflow-hidden">
           {r.image_url ? <img src={r.image_url} alt="" className="w-full h-40 object-cover" /> : <div className="h-40 bg-surface" />}
           <div className="p-3">
-            <div className="font-medium mb-2 text-headline">{r.title}</div>
+            <Link href={`/recipes/${r.id}`} className="font-medium mb-2 text-headline block hover:underline">
+              {r.title}
+            </Link>
             <div className="flex flex-wrap gap-2">
               <form action={addIngredientsToShoppingList.bind(null, r.id)}>
                 <button className="text-sm px-3 py-1 border border-primary/25 rounded-xl bg-surface">Add to shopping list</button>


### PR DESCRIPTION
## Summary
- add dynamic recipe detail page that shows image, ingredients, directions, and actions to add items to shopping list or next week's menu
- link recipe titles in list to their detail pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad4b3a09ec832aabe4a9db2a51579a