### PR TITLE
Improve recipes page with modal, tags, and sorting

### DIFF
--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -30,6 +30,13 @@ export default async function RecipePage({ params }: { params: { id: string } })
         />
       )}
       <h1 className="text-xl font-semibold text-headline">{recipe.title}</h1>
+      {recipe.tags && recipe.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {recipe.tags.map((t: string) => (
+            <span key={t} className="text-xs px-2 py-0.5 bg-primary/10 rounded-full text-headline">{t}</span>
+          ))}
+        </div>
+      )}
       {ingredients && ingredients.length > 0 && (
         <div>
           <h2 className="font-medium text-headline mb-1">Ingredients</h2>

--- a/app/recipes/page.tsx
+++ b/app/recipes/page.tsx
@@ -1,27 +1,74 @@
-import RecipeForm from '@/components/RecipeForm'
-import RecipeList from '@/components/RecipeList'
-import { supabaseServer } from '@/lib/supabaseServer'
-import { redirect } from 'next/navigation'
+import AddRecipeModal from '@/components/AddRecipeModal';
+import RecipeList from '@/components/RecipeList';
+import { supabaseServer } from '@/lib/supabaseServer';
+import { redirect } from 'next/navigation';
 
-export default async function RecipesPage() {
+export default async function RecipesPage({ searchParams }: { searchParams: { [key: string]: string | string[] | undefined } }) {
   const supabase = supabaseServer();
   const { data } = await supabase.auth.getUser();
   if (!data.user) redirect('/login');
 
-  // list recipes I own or shared to me via book_shares
-  const { data: recipes } = await supabase
+  const sortParam = typeof searchParams.sort === 'string' ? searchParams.sort : 'created_desc';
+  let column = 'created_at';
+  let ascending = false;
+  if (sortParam === 'created_asc') { column = 'created_at'; ascending = true; }
+  if (sortParam === 'title_asc') { column = 'title'; ascending = true; }
+  if (sortParam === 'title_desc') { column = 'title'; ascending = false; }
+
+  const tagFilter = typeof searchParams.tag === 'string' ? searchParams.tag : '';
+  const page = parseInt(typeof searchParams.page === 'string' ? searchParams.page : '1', 10);
+  const pageSize = 9;
+  const from = (page - 1) * pageSize;
+  const to = from + pageSize - 1;
+
+  let query = supabase
     .from('recipes_with_access')
-    .select('*')
-    .order('created_at', { ascending: false })
-    .limit(50);
+    .select('id,title,image_url,tags,created_at', { count: 'exact' })
+    .order(column, { ascending });
+  if (tagFilter) query = query.contains('tags', [tagFilter]);
+  const { data: recipes, count } = await query.range(from, to);
+  const totalPages = count ? Math.ceil(count / pageSize) : 1;
+
+  const makePageLink = (p: number) => {
+    const params = new URLSearchParams();
+    if (sortParam) params.set('sort', sortParam);
+    if (tagFilter) params.set('tag', tagFilter);
+    params.set('page', String(p));
+    return `/recipes?${params.toString()}`;
+  };
 
   return (
     <div className="space-y-6">
-      <RecipeForm />
-      <div>
-        <h2 className="font-semibold text-lg mb-2 text-headline">Your Recipes</h2>
-        <RecipeList recipes={(recipes ?? []).map(r => ({ id: r.id, title: r.title, image_url: r.image_url }))} />
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold text-lg text-headline">Your Recipes</h2>
+        <AddRecipeModal />
+      </div>
+      <form className="flex flex-wrap gap-2 items-end" method="get">
+        <div>
+          <label className="text-sm block mb-1">Sort</label>
+          <select name="sort" defaultValue={sortParam} className="border border-primary/25 rounded-xl px-3 py-2 bg-surface">
+            <option value="created_desc">Newest</option>
+            <option value="created_asc">Oldest</option>
+            <option value="title_asc">Title A-Z</option>
+            <option value="title_desc">Title Z-A</option>
+          </select>
+        </div>
+        <div>
+          <label className="text-sm block mb-1">Tag</label>
+          <input name="tag" defaultValue={tagFilter} className="border border-primary/25 rounded-xl px-3 py-2 bg-surface" />
+        </div>
+        <input type="hidden" name="page" value="1" />
+        <button className="px-3 py-2 border border-primary/25 rounded-xl bg-surface">Apply</button>
+      </form>
+      <RecipeList recipes={(recipes ?? []).map(r => ({ id: r.id, title: r.title, image_url: r.image_url, tags: r.tags }))} />
+      <div className="flex justify-between">
+        {page > 1 && (
+          <a href={makePageLink(page - 1)} className="px-3 py-1 border border-primary/25 rounded-xl bg-surface">Previous</a>
+        )}
+        {page < totalPages && (
+          <a href={makePageLink(page + 1)} className="px-3 py-1 border border-primary/25 rounded-xl bg-surface ml-auto">Next</a>
+        )}
       </div>
     </div>
-  )
+  );
 }

--- a/components/AddRecipeModal.tsx
+++ b/components/AddRecipeModal.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { useState } from 'react';
+import RecipeForm from './RecipeForm';
+
+export default function AddRecipeModal() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button onClick={() => setOpen(true)} className="px-4 py-2 rounded-xl bg-primary text-headline">Add new Recipe</button>
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-surface p-4 rounded-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto relative">
+            <button onClick={() => setOpen(false)} className="absolute top-2 right-2 text-red-600">✕</button>
+            <RecipeForm />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/RecipeForm.tsx
+++ b/components/RecipeForm.tsx
@@ -9,6 +9,8 @@ export default function RecipeForm({ bookId }: { bookId?: string | null }) {
   const [directions, setDirections] = useState('');
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [ingredients, setIngredients] = useState<IngredientInput[]>([{ name: '' }]);
+  const [tagInput, setTagInput] = useState('');
+  const [tags, setTags] = useState<string[]>([]);
 
   function updateIng(i: number, key: keyof IngredientInput, value: string) {
     setIngredients(prev => prev.map((ing, idx) => idx === i ? { ...ing, [key]: value } : ing));
@@ -16,11 +18,18 @@ export default function RecipeForm({ bookId }: { bookId?: string | null }) {
   function addIng() { setIngredients(prev => [...prev, { name: '' }]); }
   function removeIng(i: number) { setIngredients(prev => prev.filter((_, idx) => idx !== i)); }
 
+  function addTag() {
+    const t = tagInput.trim();
+    if (t && !tags.includes(t)) setTags(prev => [...prev, t]);
+    setTagInput('');
+  }
+  function removeTag(t: string) { setTags(prev => prev.filter(tag => tag !== t)); }
+
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
     const cleaned = ingredients.filter(i => i.name.trim().length);
-    await createRecipe({ title, directions, image_url: imageUrl, ingredients: cleaned, book_id: bookId ?? null });
-    setTitle(''); setDirections(''); setImageUrl(null); setIngredients([{ name: '' }]);
+    await createRecipe({ title, directions, image_url: imageUrl, ingredients: cleaned, book_id: bookId ?? null, tags });
+    setTitle(''); setDirections(''); setImageUrl(null); setIngredients([{ name: '' }]); setTags([]);
   }
 
     return (
@@ -44,6 +53,21 @@ export default function RecipeForm({ bookId }: { bookId?: string | null }) {
               </div>
             ))}
             <button type="button" onClick={addIng} className="text-sm text-primary">+ Add ingredient</button>
+          </div>
+        </div>
+        <div>
+          <p className="text-sm font-medium mb-1 text-headline">Tags</p>
+          <div className="flex flex-wrap gap-2 mb-2">
+            {tags.map(t => (
+              <span key={t} className="px-2 py-1 text-sm rounded-xl bg-primary/10 text-headline flex items-center gap-1">
+                {t}
+                <button type="button" onClick={() => removeTag(t)} className="text-red-600">✕</button>
+              </span>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <input className="flex-1 border border-primary/25 rounded-xl px-3 py-2 bg-surface" placeholder="New tag" value={tagInput} onChange={e => setTagInput(e.target.value)} />
+            <button type="button" onClick={addTag} className="px-3 py-2 border border-primary/25 rounded-xl bg-surface">Add</button>
           </div>
         </div>
         <button className="px-4 py-2 rounded-xl bg-primary text-headline">Save Recipe</button>

--- a/components/RecipeList.tsx
+++ b/components/RecipeList.tsx
@@ -6,6 +6,7 @@ type Recipe = {
   id: string;
   title: string;
   image_url: string | null;
+  tags?: string[] | null;
 };
 
 export default function RecipeList({ recipes }:{ recipes: Recipe[] }) {
@@ -18,6 +19,13 @@ export default function RecipeList({ recipes }:{ recipes: Recipe[] }) {
             <Link href={`/recipes/${r.id}`} className="font-medium mb-2 text-headline block hover:underline">
               {r.title}
             </Link>
+            {r.tags && r.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1 mb-2">
+                {r.tags.map(t => (
+                  <span key={t} className="text-xs px-2 py-0.5 bg-primary/10 rounded-full text-headline">{t}</span>
+                ))}
+              </div>
+            )}
             <div className="flex flex-wrap gap-2">
               <form action={addIngredientsToShoppingList.bind(null, r.id)}>
                 <button className="text-sm px-3 py-1 border border-primary/25 rounded-xl bg-surface">Add to shopping list</button>

--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -24,6 +24,7 @@ export async function createRecipe(data: RecipeInput) {
       directions: data.directions ?? null,
       image_url: data.image_url ?? null,
       book_id: data.book_id ?? null,
+      tags: data.tags ?? [],
     })
     .select()
     .single();

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,6 +10,7 @@ export type RecipeInput = {
   image_url?: string | null;
   ingredients: IngredientInput[];
   book_id?: string | null;
+  tags?: string[];
 };
 
 export type Weekday =


### PR DESCRIPTION
## Summary
- add tag support in recipes and creation workflow
- introduce sortable, filterable, paginated recipes list
- move recipe creation into modal dialog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad555605f8832a88f76aff5de12f3b