### PR TITLE
feat: allow editing and deleting recipes

### DIFF
--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { supabaseServer } from '@/lib/supabaseServer';
 import { addIngredientsToShoppingList, addRecipeToNextWeekMenu } from '@/lib/actions';
+import EditRecipeModal from '@/components/EditRecipeModal';
+import DeleteRecipeButton from '@/components/DeleteRecipeButton';
 import { weekdayNames } from '@/lib/date';
 import { redirect, notFound } from 'next/navigation';
 
@@ -19,9 +21,14 @@ export default async function RecipePage({ params }: { params: { id: string } })
     .from('recipe_ingredients')
     .select('id, name, quantity, unit')
     .eq('recipe_id', params.id);
+  const recipeForEdit = { ...recipe, ingredients: ingredients ?? [] };
 
   return (
     <div className="space-y-4">
+      <div className="flex justify-end gap-2">
+        <EditRecipeModal recipe={recipeForEdit} />
+        <DeleteRecipeButton recipeId={recipe.id} />
+      </div>
       {recipe.image_url && (
         <img
           src={recipe.image_url}

--- a/components/DeleteRecipeButton.tsx
+++ b/components/DeleteRecipeButton.tsx
@@ -1,0 +1,14 @@
+'use client';
+import { deleteRecipe } from '@/lib/actions';
+
+export default function DeleteRecipeButton({ recipeId }: { recipeId: string }) {
+  async function onDelete() {
+    if (confirm('Delete this recipe?')) {
+      await deleteRecipe(recipeId);
+      window.location.href = '/recipes';
+    }
+  }
+  return (
+    <button onClick={onDelete} className="px-3 py-2 border border-primary/25 rounded-xl bg-surface text-red-600">Delete</button>
+  );
+}

--- a/components/EditRecipeModal.tsx
+++ b/components/EditRecipeModal.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useState } from 'react';
+import RecipeForm from './RecipeForm';
+import type { IngredientInput } from '@/lib/types';
+
+type RecipeForEdit = {
+  id: string;
+  title: string;
+  directions?: string | null;
+  image_url?: string | null;
+  ingredients: IngredientInput[];
+  book_id?: string | null;
+  tags?: string[];
+};
+
+export default function EditRecipeModal({ recipe }: { recipe: RecipeForEdit }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button onClick={() => setOpen(true)} className="px-4 py-2 rounded-xl bg-primary text-headline">Edit</button>
+      {open && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-surface p-4 rounded-2xl w-full max-w-lg max-h-[90vh] overflow-y-auto relative">
+            <button onClick={() => setOpen(false)} className="absolute top-2 right-2 text-red-600">✕</button>
+            <RecipeForm recipe={recipe} onSaved={() => setOpen(false)} />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add server actions to update and delete recipes
- reuse RecipeForm for editing and provide modal and button components
- expose edit and delete controls on recipe pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad5fce92a8832a85686cd3867fce16