### PR TITLE
Dark themed mobile header with logo

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,16 +3,16 @@
 @tailwind utilities;
 
 :root {
-  --bg: #0B1220;
-  --surface: #0F172A;
-  --text: #C7EDE3;
-  --headline: #ECFEFF;
-  --primary: #10B981;
-  --primaryDark: #0F766E;
-  --accent: #38BDF8;
-  --muted: #94A3B8;
-  --ring: rgba(16,185,129,0.25);
-  --success: #22C55E;
+  --bg: #000814;
+  --surface: #001d3d;
+  --text: #cbd5e1;
+  --headline: #e2e8f0;
+  --primary: #003566;
+  --primaryDark: #00274d;
+  --accent: #ff4d6d;
+  --muted: #64748b;
+  --ring: rgba(255,77,109,0.25);
+  --success: #16a34a;
 }
 
 html, body, #__next { height: 100%; }
@@ -30,4 +30,7 @@ input, textarea, select {
 
 button {
   color: var(--headline);
+  background: var(--accent);
+  border-radius: 9999px;
+  padding: 0.5rem 1rem;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,11 @@
 import './globals.css'
 import Link from 'next/link'
+import Image from 'next/image'
 import { supabaseServer } from '@/lib/supabaseServer'
 import { redirect } from 'next/navigation'
 
 export const metadata = {
-  title: 'Recipe Planner',
+  title: 'Week Bite',
   description: 'Recipes • Shopping • Weekly Menu',
 }
 
@@ -13,7 +14,7 @@ async function UserMenu() {
   const { data } = await supabase.auth.getUser();
   const user = data.user;
   if (!user) {
-    return <Link href="/login" className="text-sm px-3 py-1 rounded bg-primary text-headline">Log in</Link>
+    return <Link href="/login" className="px-4 py-2 rounded-full bg-accent text-headline text-sm">Log in</Link>
   }
   async function signOut() {
     'use server'
@@ -23,7 +24,7 @@ async function UserMenu() {
   }
   return (
     <form action={signOut}>
-      <button className="text-sm px-3 py-1 rounded bg-primaryDark text-headline">Sign out</button>
+      <button className="text-sm px-4 py-2 rounded-full bg-accent text-headline">Sign out</button>
     </form>
   )
 }
@@ -33,15 +34,19 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en">
       <body className="min-h-screen bg-bg text-text">
         <header className="border-b border-primary/25 bg-surface sticky top-0 z-10">
-          <div className="max-w-5xl mx-auto px-4 py-3 flex items-center justify-between text-headline">
-            <Link href="/" className="font-semibold text-lg text-headline">🥗 Recipe Planner</Link>
-            <nav className="flex items-center gap-3 text-sm">
-              <Link href="/recipes" className="hover:text-primary">Recipes</Link>
-              <Link href="/shopping" className="hover:text-primary">Shopping</Link>
-              <Link href="/menu" className="hover:text-primary">Weekly Menu</Link>
-              <Link href="/friends" className="hover:text-primary">Friends</Link>
+          <div className="max-w-5xl mx-auto px-4 py-3 flex flex-wrap items-center justify-between gap-4 text-headline">
+            <Link href="/" className="flex items-center">
+              <Image src="/logo.svg" alt="Week Bite" width={120} height={40} priority />
+            </Link>
+            <nav className="w-full sm:w-auto flex flex-wrap justify-center gap-2 text-sm">
+              <Link href="/recipes" className="px-4 py-2 rounded-full bg-primary text-headline hover:bg-primaryDark">Recipes</Link>
+              <Link href="/shopping" className="px-4 py-2 rounded-full bg-primary text-headline hover:bg-primaryDark">Shopping</Link>
+              <Link href="/menu" className="px-4 py-2 rounded-full bg-primary text-headline hover:bg-primaryDark">Weekly Menu</Link>
+              <Link href="/friends" className="px-4 py-2 rounded-full bg-primary text-headline hover:bg-primaryDark">Friends</Link>
             </nav>
-            <UserMenu />
+            <div className="flex sm:ml-auto">
+              <UserMenu />
+            </div>
           </div>
         </header>
         <main className="max-w-5xl mx-auto px-4 py-6">{children}</main>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,6 @@
+<svg width="200" height="80" viewBox="0 0 200 80" xmlns="http://www.w3.org/2000/svg">
+  <rect width="200" height="80" fill="none"/>
+  <circle cx="40" cy="40" r="30" fill="#0E1F33"/>
+  <rect x="30" y="25" width="40" height="40" rx="5" fill="#FF5A5F" stroke="#0E1F33" stroke-width="4"/>
+  <text x="90" y="50" font-size="32" font-family="Arial, sans-serif" fill="#0E1F33">Week Bite</text>
+</svg>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,16 +7,16 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        primary: '#10B981',  // mint
-        primaryDark: '#0F766E',
-        accent: '#38BDF8',  // brighter sky
-        bg: '#0B1220',  // midnight
-        surface: '#0F172A',  // cards/navbar
-        text: '#C7EDE3',  // body on dark
-        headline: '#ECFEFF',  // titles on dark
-        muted: '#94A3B8',  // meta text
-        ring: 'rgba(16,185,129,0.25)',
-        success: '#22C55E'
+        primary: '#003566',  // deep blue
+        primaryDark: '#00274d',
+        accent: '#ff4d6d',  // logo red
+        bg: '#000814',  // very dark background
+        surface: '#001d3d',  // navbar/cards
+        text: '#cbd5e1',  // body on dark
+        headline: '#e2e8f0',  // titles on dark
+        muted: '#64748b',  // meta text
+        ring: 'rgba(255,77,109,0.25)',
+        success: '#16a34a'
       }
     },
   },


### PR DESCRIPTION
## Summary
- Revamp Tailwind palette to use deep blues and a red accent for a dark theme
- Apply global dark variables and rounded playful buttons
- Add responsive header with Week Bite logo and button-style navigation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad8bfdcac4832aa6c88383cde34bfb